### PR TITLE
fix: resolve UnicodeDecodeError on Windows

### DIFF
--- a/src/uv_ship/resources/__init__.py
+++ b/src/uv_ship/resources/__init__.py
@@ -3,19 +3,20 @@ import json
 
 from .rich_click_theme import rich_click as rich_click
 
+symbols = {}
+ansi_codes = {}
+tagline = ''
+
 path = resources.files('uv_ship.resources')
 for cont in path.iterdir():
     if cont.name == 'symbols.json':
-        with open(cont, 'r') as f:
-            symbols = json.load(f)
+        symbols = json.loads(cont.read_text(encoding='utf-8'))
 
     if cont.name == 'ansi.json':
-        with open(cont, 'r') as f:
-            ansi_codes = json.load(f)
+        ansi_codes = json.loads(cont.read_text(encoding='utf-8'))
 
     if cont.name == 'tagline.md':
-        with open(cont, 'r') as f:
-            tagline = cont.read_text(encoding='utf-8')
+        tagline = cont.read_text(encoding='utf-8')
 
 
 class Symbols:


### PR DESCRIPTION
- Add explicit encoding='utf-8' when reading JSON resource files
- Fix UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 
  (see https://github.com/floRaths/uv-ship/issues/7)
- Initialize variables to prevent unbound variable issues